### PR TITLE
rpi: add support for pi 400 & pi 4B 8GB

### DIFF
--- a/rpi/rpi.go
+++ b/rpi/rpi.go
@@ -384,6 +384,7 @@ const (
 	memory1GB   revisionCode = 2 << memoryShift
 	memory2GB   revisionCode = 3 << memoryShift
 	memory4GB   revisionCode = 4 << memoryShift
+	memory8GB   revisionCode = 5 << memoryShift
 
 	sonyUK    revisionCode = 0 << manufacturerShift
 	egoman    revisionCode = 1 << manufacturerShift
@@ -413,6 +414,7 @@ const (
 	boardReserved revisionCode = 0xf << boardShift
 	boardCM3Plus  revisionCode = 0x10 << boardShift
 	board4B       revisionCode = 0x11 << boardShift
+	board400      revisionCode = 0x13 << boardShift
 )
 
 // features represents the different features on various Raspberry Pi boards.
@@ -501,6 +503,9 @@ func (f *features) init(v uint32) error {
 		f.hdrP1P40 = true
 		f.hdrAudio = true
 		f.audioLeft41 = true
+		f.hdrHDMI = true
+	case board400:
+		f.hdrP1P40 = true
 		f.hdrHDMI = true
 	default:
 		return fmt.Errorf("rpi: unknown hardware version: 0x%x", r)

--- a/rpi/rpi_test.go
+++ b/rpi/rpi_test.go
@@ -61,6 +61,12 @@ func TestParseRevision(t *testing.T) {
 		{0xa03111, newFormat | memory1GB | sonyUK | bcm2711 | board4B | 1},
 		{0xb03111, newFormat | memory2GB | sonyUK | bcm2711 | board4B | 1},
 		{0xc03111, newFormat | memory4GB | sonyUK | bcm2711 | board4B | 1},
+		{0xb03112, newFormat | memory2GB | sonyUK | bcm2711 | board4B | 2},
+		{0xc03112, newFormat | memory4GB | sonyUK | bcm2711 | board4B | 2},
+		{0xb03114, newFormat | memory2GB | sonyUK | bcm2711 | board4B | 4},
+		{0xc03114, newFormat | memory4GB | sonyUK | bcm2711 | board4B | 4},
+		{0xd03114, newFormat | memory8GB | sonyUK | bcm2711 | board4B | 4},
+		{0xc03130, newFormat | memory4GB | sonyUK | bcm2711 | board400},
 	}
 	for i, line := range data {
 		r, err := parseRevision(line.v)
@@ -129,6 +135,7 @@ func TestFeaturesInit(t *testing.T) {
 		{0xa03111, features{hdrP1P40: true, hdrAudio: true, audioLeft41: true, hdrHDMI: true}}, // board4B
 		{0xb03111, features{hdrP1P40: true, hdrAudio: true, audioLeft41: true, hdrHDMI: true}}, // board4B
 		{0xc03111, features{hdrP1P40: true, hdrAudio: true, audioLeft41: true, hdrHDMI: true}}, // board4B
+		{0xc03130, features{hdrP1P40: true, hdrHDMI: true}},                                    // board400
 	}
 	for i, line := range data {
 		f := features{}


### PR DESCRIPTION
This PR adds support for the raspberry pi 400 board (tested on mine), and support for the 8GB RAM version of the pi 4B

Also:
- add unit tests for revision 1.2 of pi 4B boards (2 and 4GB)
- add unit tests for revision 1.4 of pi 4B boards (2, 4 and 8GB)
- add unit tests for pi 400 (revision 1.0)
