### PR TITLE
bcm283x: Don't override previous pull states

### DIFF
--- a/bcm283x/gpio.go
+++ b/bcm283x/gpio.go
@@ -432,8 +432,9 @@ func (p *Pin) In(pull gpio.Pull, edge gpio.Edge) error {
 				pullState = 0
 			}
 
-			previous := drvGPIO.gpioMemory.pullRegister[offset]
-			drvGPIO.gpioMemory.pullRegister[offset] = previous | (pullState << uint((p.number%16)<<1))
+			bitOffset := 2 * uint(p.number%16)
+			previous := drvGPIO.gpioMemory.pullRegister[offset] & ^(3 << bitOffset)
+			drvGPIO.gpioMemory.pullRegister[offset] = previous | (pullState << bitOffset)
 		} else {
 			// Set Pull
 			switch pull {


### PR DESCRIPTION
Currently the pull resistors are being overridden when a new GPIO is set on the same byte space. 

This case:
```golang
rpi.P1_12.In(gpio.PullDown, gpio.RisingEdge)
fmt.Printf("Pull State (Before) %s\n", rpi.P1_12.Pull())
rpi.P1_16.In(gpio.Float, gpio.NoEdge)
fmt.Printf("Pull State (After) %s %d\n", rpi.P1_12.Pull())
``` 
Will end up printing:

```
Pull State (Before) PullDown
Pull State (After) Float
```

The fix maintains the bits that are not being touched.
