### PR TITLE
rpi: Added support for RPi Zero2W and CM4

### DIFF
--- a/rpi/rpi.go
+++ b/rpi/rpi.go
@@ -414,7 +414,9 @@ const (
 	boardReserved revisionCode = 0xf << boardShift
 	boardCM3Plus  revisionCode = 0x10 << boardShift
 	board4B       revisionCode = 0x11 << boardShift
+	boardZero2W   revisionCode = 0x12 << boardShift
 	board400      revisionCode = 0x13 << boardShift
+	boardCM4      revisionCode = 0x14 << boardShift
 )
 
 // features represents the different features on various Raspberry Pi boards.
@@ -504,9 +506,14 @@ func (f *features) init(v uint32) error {
 		f.hdrAudio = true
 		f.audioLeft41 = true
 		f.hdrHDMI = true
+	case boardZero2W:
+		f.hdrP1P40 = true
+		f.hdrHDMI = true
 	case board400:
 		f.hdrP1P40 = true
 		f.hdrHDMI = true
+	case boardCM4:
+		// Compute Module does not have a SODIMM header.
 	default:
 		return fmt.Errorf("rpi: unknown hardware version: 0x%x", r)
 	}

--- a/rpi/rpi_test.go
+++ b/rpi/rpi_test.go
@@ -67,6 +67,11 @@ func TestParseRevision(t *testing.T) {
 		{0xc03114, newFormat | memory4GB | sonyUK | bcm2711 | board4B | 4},
 		{0xd03114, newFormat | memory8GB | sonyUK | bcm2711 | board4B | 4},
 		{0xc03130, newFormat | memory4GB | sonyUK | bcm2711 | board400},
+		{0xa03140, newFormat | memory1GB | sonyUK | bcm2711 | boardCM4},
+		{0xb03140, newFormat | memory2GB | sonyUK | bcm2711 | boardCM4},
+		{0xc03140, newFormat | memory4GB | sonyUK | bcm2711 | boardCM4},
+		{0xd03140, newFormat | memory8GB | sonyUK | bcm2711 | boardCM4},
+		{0x902120, newFormat | memory512MB | sonyUK | bcm2837 | boardZero2W},
 	}
 	for i, line := range data {
 		r, err := parseRevision(line.v)
@@ -136,6 +141,11 @@ func TestFeaturesInit(t *testing.T) {
 		{0xb03111, features{hdrP1P40: true, hdrAudio: true, audioLeft41: true, hdrHDMI: true}}, // board4B
 		{0xc03111, features{hdrP1P40: true, hdrAudio: true, audioLeft41: true, hdrHDMI: true}}, // board4B
 		{0xc03130, features{hdrP1P40: true, hdrHDMI: true}},                                    // board400
+		{0xa03140, features{}},                              // boardCM4
+		{0xb03140, features{}},                              // boardCM4
+		{0xc03140, features{}},                              // boardCM4
+		{0xd03140, features{}},                              // boardCM4
+		{0x902120, features{hdrP1P40: true, hdrHDMI: true}}, // boardZero2W
 	}
 	for i, line := range data {
 		f := features{}


### PR DESCRIPTION
Add support for new Raspberry Pi Zero 2W and the Compute Module 4 (all memory sizes)
