### PR TITLE
serial: Fix serial so it can be used

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,7 +13,7 @@ Steps to reproduce the behavior:
 package main
 
 import (
-  "periph.io/x/host/v3"
+  "adev73/x/host/v3"
 )
 
 func main() {

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 1. Please prefix the issue title with the primary package affected. For example,
-if this PR fixes periph.io/x/host/v3/sysfs, prefix the PR title with "sysfs:".
+if this PR fixes adev73/x/host/v3/sysfs, prefix the PR title with "sysfs:".
 
 2. Mention the issue number it fixes or add the details of the changes if it
 doesn't have a specific issue. Examples:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -242,7 +242,7 @@ jobs:
         cd ..
         git clone --depth 1 https://github.com/periph/devices
         cd devices
-        go mod edit -replace=periph.io/x/host/v3=../host
+        go mod edit -replace=adev73/x/host/v3=../host
         go get -t ./...
         go test -short ./...
 
@@ -252,7 +252,7 @@ jobs:
         cd ..
         git clone --depth 1 https://github.com/periph/cmd
         cd cmd
-        go mod edit -replace=periph.io/x/host/v3=../host
+        go mod edit -replace=adev73/x/host/v3=../host
         go get -t ./...
         go test -short ./...
 

--- a/.gohci.yml
+++ b/.gohci.yml
@@ -30,7 +30,7 @@ workers:
     - go
     - mod
     - edit
-    - -replace=periph.io/x/host/v3=../host
+    - -replace=adev73/x/host/v3=../host
   - dir: ../devices
     cmd:
     - go
@@ -56,7 +56,7 @@ workers:
     - go
     - mod
     - edit
-    - -replace=periph.io/x/host/v3=../host
+    - -replace=adev73/x/host/v3=../host
   - dir: ../cmd
     cmd:
     - go
@@ -122,7 +122,7 @@ workers:
     - go
     - mod
     - edit
-    - -replace=periph.io/x/host/v3=../host
+    - -replace=adev73/x/host/v3=../host
   - dir: ../devices
     cmd:
     - go
@@ -148,7 +148,7 @@ workers:
     - go
     - mod
     - edit
-    - -replace=periph.io/x/host/v3=../host
+    - -replace=adev73/x/host/v3=../host
   - dir: ../cmd
     cmd:
     - go
@@ -228,7 +228,7 @@ workers:
     - go
     - mod
     - edit
-    - -replace=periph.io/x/host/v3=../host
+    - -replace=adev73/x/host/v3=../host
   - dir: ../devices
     cmd:
     - go
@@ -254,7 +254,7 @@ workers:
     - go
     - mod
     - edit
-    - -replace=periph.io/x/host/v3=../host
+    - -replace=adev73/x/host/v3=../host
   - dir: ../cmd
     cmd:
     - go
@@ -355,7 +355,7 @@ workers:
     - go
     - mod
     - edit
-    - -replace=periph.io/x/host/v3=../host
+    - -replace=adev73/x/host/v3=../host
   - dir: ../devices
     cmd:
     - go
@@ -381,7 +381,7 @@ workers:
     - go
     - mod
     - edit
-    - -replace=periph.io/x/host/v3=../host
+    - -replace=adev73/x/host/v3=../host
   - dir: ../cmd
     cmd:
     - go
@@ -448,7 +448,7 @@ workers:
     - go
     - mod
     - edit
-    - -replace=periph.io/x/host/v3=../host
+    - -replace=adev73/x/host/v3=../host
   - dir: ../devices
     cmd:
     - go
@@ -474,7 +474,7 @@ workers:
     - go
     - mod
     - edit
-    - -replace=periph.io/x/host/v3=../host
+    - -replace=adev73/x/host/v3=../host
   - dir: ../cmd
     cmd:
     - go

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ get an [invite here](https://invite.slack.golangbridge.org/).
 
 [![mascot](https://raw.githubusercontent.com/periph/website/master/site/static/img/periph-mascot-280.png)](https://periph.io/)
 
-[![PkgGoDev](https://pkg.go.dev/badge/periph.io/x/host/v3)](https://pkg.go.dev/periph.io/x/host/v3)
+[![PkgGoDev](https://pkg.go.dev/badge/adev73/x/host/v3)](https://pkg.go.dev/adev73/x/host/v3)
 [![codecov](https://codecov.io/gh/periph/host/branch/main/graph/badge.svg?token=RX9O1CPQHU)](https://codecov.io/gh/periph/host)
 
 
@@ -22,8 +22,8 @@ package main
 import (
     "time"
     "periph.io/x/conn/v3/gpio"
-    "periph.io/x/host/v3"
-    "periph.io/x/host/v3/rpi"
+    "adev73/x/host/v3"
+    "adev73/x/host/v3/rpi"
 )
 
 func main() {

--- a/allwinner/a20.go
+++ b/allwinner/a20.go
@@ -10,8 +10,9 @@ package allwinner
 import (
 	"strings"
 
+	"adev73/x/host/v3/sysfs"
+
 	"periph.io/x/conn/v3/pin"
-	"periph.io/x/host/v3/sysfs"
 )
 
 // mappingA20 describes the mapping of the A20 processor gpios to their

--- a/allwinner/a64.go
+++ b/allwinner/a64.go
@@ -10,8 +10,9 @@ package allwinner
 import (
 	"strings"
 
+	"adev73/x/host/v3/sysfs"
+
 	"periph.io/x/conn/v3/pin"
-	"periph.io/x/host/v3/sysfs"
 )
 
 // A64 specific pins.

--- a/allwinner/allwinnersmoketest/allwinnersmoketest.go
+++ b/allwinner/allwinnersmoketest/allwinnersmoketest.go
@@ -15,10 +15,11 @@ import (
 	"fmt"
 	"time"
 
+	"adev73/x/host/v3/allwinner"
+	"adev73/x/host/v3/chip"
+	"adev73/x/host/v3/pine64"
+
 	"periph.io/x/conn/v3/gpio"
-	"periph.io/x/host/v3/allwinner"
-	"periph.io/x/host/v3/chip"
-	"periph.io/x/host/v3/pine64"
 )
 
 // SmokeTest is imported by periph-smoketest.

--- a/allwinner/allwinnersmoketest/benchmark.go
+++ b/allwinner/allwinnersmoketest/benchmark.go
@@ -9,9 +9,10 @@ import (
 	"flag"
 	"fmt"
 
+	"adev73/x/host/v3/allwinner"
+
 	"periph.io/x/conn/v3/gpio"
 	"periph.io/x/conn/v3/gpio/gpioreg"
-	"periph.io/x/host/v3/allwinner"
 )
 
 // Benchmark is imported by periph-smoketest.

--- a/allwinner/detect.go
+++ b/allwinner/detect.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"sync"
 
-	"periph.io/x/host/v3/distro"
+	"adev73/x/host/v3/distro"
 )
 
 // Present detects whether the host CPU is an Allwinner CPU.

--- a/allwinner/dma.go
+++ b/allwinner/dma.go
@@ -21,8 +21,9 @@ import (
 	"log"
 	"os"
 
+	"adev73/x/host/v3/pmem"
+
 	"periph.io/x/conn/v3/driver/driverreg"
-	"periph.io/x/host/v3/pmem"
 )
 
 // dmaMap represents the DMA memory mapped CPU registers.

--- a/allwinner/gpio.go
+++ b/allwinner/gpio.go
@@ -16,13 +16,14 @@ import (
 	"strings"
 	"time"
 
+	"adev73/x/host/v3/pmem"
+	"adev73/x/host/v3/sysfs"
+
 	"periph.io/x/conn/v3/driver/driverreg"
 	"periph.io/x/conn/v3/gpio"
 	"periph.io/x/conn/v3/gpio/gpioreg"
 	"periph.io/x/conn/v3/physic"
 	"periph.io/x/conn/v3/pin"
-	"periph.io/x/host/v3/pmem"
-	"periph.io/x/host/v3/sysfs"
 )
 
 // List of all known pins. These global variables can be used directly.

--- a/allwinner/gpio_pl.go
+++ b/allwinner/gpio_pl.go
@@ -13,13 +13,14 @@ import (
 	"strings"
 	"time"
 
+	"adev73/x/host/v3/pmem"
+	"adev73/x/host/v3/sysfs"
+
 	"periph.io/x/conn/v3/driver/driverreg"
 	"periph.io/x/conn/v3/gpio"
 	"periph.io/x/conn/v3/gpio/gpioreg"
 	"periph.io/x/conn/v3/physic"
 	"periph.io/x/conn/v3/pin"
-	"periph.io/x/host/v3/pmem"
-	"periph.io/x/host/v3/sysfs"
 )
 
 // All the pins in the PL group.

--- a/allwinner/r8.go
+++ b/allwinner/r8.go
@@ -10,8 +10,9 @@ package allwinner
 import (
 	"strings"
 
+	"adev73/x/host/v3/sysfs"
+
 	"periph.io/x/conn/v3/pin"
-	"periph.io/x/host/v3/sysfs"
 )
 
 // R8 specific pins.

--- a/allwinner/timer.go
+++ b/allwinner/timer.go
@@ -7,7 +7,7 @@ package allwinner
 import (
 	"time"
 
-	"periph.io/x/host/v3/cpu"
+	"adev73/x/host/v3/cpu"
 )
 
 // ReadTime returns the time on a monotonic timer.

--- a/am335x/am335x.go
+++ b/am335x/am335x.go
@@ -8,8 +8,9 @@ import (
 	"errors"
 	"strings"
 
+	"adev73/x/host/v3/distro"
+
 	"periph.io/x/conn/v3/driver/driverreg"
-	"periph.io/x/host/v3/distro"
 )
 
 // Present returns true if a TM AM335x processor is detected.

--- a/bcm283x/bcm283x_test.go
+++ b/bcm283x/bcm283x_test.go
@@ -4,7 +4,7 @@
 
 package bcm283x
 
-import "periph.io/x/host/v3/fs"
+import "adev73/x/host/v3/fs"
 
 func init() {
 	fs.Inhibit()

--- a/bcm283x/bcm283xsmoketest/bcm283xsmoketest.go
+++ b/bcm283x/bcm283xsmoketest/bcm283xsmoketest.go
@@ -15,11 +15,12 @@ import (
 	"reflect"
 	"time"
 
+	"adev73/x/host/v3/bcm283x"
+
 	"periph.io/x/conn/v3/gpio"
 	"periph.io/x/conn/v3/gpio/gpiostream"
 	"periph.io/x/conn/v3/physic"
 	"periph.io/x/conn/v3/pin"
-	"periph.io/x/host/v3/bcm283x"
 )
 
 // SmokeTest is imported by periph-smoketest.

--- a/bcm283x/bcm283xsmoketest/benchmark.go
+++ b/bcm283x/bcm283xsmoketest/benchmark.go
@@ -9,9 +9,10 @@ import (
 	"flag"
 	"fmt"
 
+	"adev73/x/host/v3/bcm283x"
+
 	"periph.io/x/conn/v3/gpio"
 	"periph.io/x/conn/v3/gpio/gpioreg"
-	"periph.io/x/host/v3/bcm283x"
 )
 
 // Benchmark is imported by periph-smoketest.

--- a/bcm283x/dma.go
+++ b/bcm283x/dma.go
@@ -70,11 +70,12 @@ import (
 	"strings"
 	"time"
 
+	"adev73/x/host/v3/pmem"
+	"adev73/x/host/v3/videocore"
+
 	"periph.io/x/conn/v3/driver/driverreg"
 	"periph.io/x/conn/v3/gpio/gpiostream"
 	"periph.io/x/conn/v3/physic"
-	"periph.io/x/host/v3/pmem"
-	"periph.io/x/host/v3/videocore"
 )
 
 const (

--- a/bcm283x/example_test.go
+++ b/bcm283x/example_test.go
@@ -8,9 +8,10 @@ import (
 	"fmt"
 	"log"
 
+	"adev73/x/host/v3"
+	"adev73/x/host/v3/bcm283x"
+
 	"periph.io/x/conn/v3/physic"
-	"periph.io/x/host/v3"
-	"periph.io/x/host/v3/bcm283x"
 )
 
 func ExamplePinsRead0To31() {

--- a/bcm283x/gpio.go
+++ b/bcm283x/gpio.go
@@ -12,16 +12,17 @@ import (
 	"strings"
 	"time"
 
+	"adev73/x/host/v3/distro"
+	"adev73/x/host/v3/pmem"
+	"adev73/x/host/v3/sysfs"
+	"adev73/x/host/v3/videocore"
+
 	"periph.io/x/conn/v3/driver/driverreg"
 	"periph.io/x/conn/v3/gpio"
 	"periph.io/x/conn/v3/gpio/gpioreg"
 	"periph.io/x/conn/v3/gpio/gpiostream"
 	"periph.io/x/conn/v3/physic"
 	"periph.io/x/conn/v3/pin"
-	"periph.io/x/host/v3/distro"
-	"periph.io/x/host/v3/pmem"
-	"periph.io/x/host/v3/sysfs"
-	"periph.io/x/host/v3/videocore"
 )
 
 // All the pins supported by the CPU.

--- a/bcm283x/gpio_test.go
+++ b/bcm283x/gpio_test.go
@@ -8,6 +8,9 @@ import (
 	"reflect"
 	"testing"
 
+	"adev73/x/host/v3/pmem"
+	"adev73/x/host/v3/videocore"
+
 	"periph.io/x/conn/v3/gpio"
 	"periph.io/x/conn/v3/gpio/gpiostream"
 	"periph.io/x/conn/v3/i2c"
@@ -15,8 +18,6 @@ import (
 	"periph.io/x/conn/v3/pin"
 	"periph.io/x/conn/v3/spi"
 	"periph.io/x/conn/v3/uart"
-	"periph.io/x/host/v3/pmem"
-	"periph.io/x/host/v3/videocore"
 )
 
 func TestPresent(t *testing.T) {

--- a/bcm283x/timer.go
+++ b/bcm283x/timer.go
@@ -7,7 +7,7 @@ package bcm283x
 import (
 	"time"
 
-	"periph.io/x/host/v3/cpu"
+	"adev73/x/host/v3/cpu"
 )
 
 // ReadTime returns the time on a monotonic 1Mhz clock (1µs resolution).

--- a/beagle/beagle.go
+++ b/beagle/beagle.go
@@ -7,7 +7,7 @@ package beagle
 import (
 	"strings"
 
-	"periph.io/x/host/v3/distro"
+	"adev73/x/host/v3/distro"
 )
 
 // Present returns true if the host is a BeagleBone.

--- a/beagle/black/black.go
+++ b/beagle/black/black.go
@@ -21,7 +21,7 @@ package black
 import (
 	"strings"
 
-	"periph.io/x/host/v3/distro"
+	"adev73/x/host/v3/distro"
 )
 
 // Present returns true if the host is a BeagleBone Black or BeagleBone Black

--- a/beagle/bone/bone.go
+++ b/beagle/bone/bone.go
@@ -16,13 +16,14 @@ package bone
 import (
 	"errors"
 
+	"adev73/x/host/v3/beagle/black"
+	"adev73/x/host/v3/beagle/green"
+	"adev73/x/host/v3/sysfs"
+
 	"periph.io/x/conn/v3/driver/driverreg"
 	"periph.io/x/conn/v3/gpio"
 	"periph.io/x/conn/v3/pin"
 	"periph.io/x/conn/v3/pin/pinreg"
-	"periph.io/x/host/v3/beagle/black"
-	"periph.io/x/host/v3/beagle/green"
-	"periph.io/x/host/v3/sysfs"
 )
 
 // TODO(maruel): Use specialized am335x or pru implementation once available.

--- a/beagle/green/green.go
+++ b/beagle/green/green.go
@@ -20,12 +20,13 @@ import (
 	"errors"
 	"strings"
 
+	"adev73/x/host/v3/distro"
+	"adev73/x/host/v3/sysfs"
+
 	"periph.io/x/conn/v3/driver/driverreg"
 	"periph.io/x/conn/v3/gpio"
 	"periph.io/x/conn/v3/pin"
 	"periph.io/x/conn/v3/pin/pinreg"
-	"periph.io/x/host/v3/distro"
-	"periph.io/x/host/v3/sysfs"
 )
 
 // Headers found on BeagleBone Green.

--- a/chip/chip.go
+++ b/chip/chip.go
@@ -13,14 +13,15 @@ import (
 	"strconv"
 	"strings"
 
+	"adev73/x/host/v3/allwinner"
+	"adev73/x/host/v3/distro"
+	"adev73/x/host/v3/fs"
+
 	"periph.io/x/conn/v3/driver/driverreg"
 	"periph.io/x/conn/v3/gpio"
 	"periph.io/x/conn/v3/gpio/gpioreg"
 	"periph.io/x/conn/v3/pin"
 	"periph.io/x/conn/v3/pin/pinreg"
-	"periph.io/x/host/v3/allwinner"
-	"periph.io/x/host/v3/distro"
-	"periph.io/x/host/v3/fs"
 )
 
 // C.H.I.P. hardware pins.

--- a/chip/chipsmoketest/chipsmoketest.go
+++ b/chip/chipsmoketest/chipsmoketest.go
@@ -13,11 +13,12 @@ import (
 	"sort"
 	"strconv"
 
+	"adev73/x/host/v3/allwinner"
+	"adev73/x/host/v3/chip"
+
 	"periph.io/x/conn/v3/gpio"
 	"periph.io/x/conn/v3/gpio/gpioreg"
 	"periph.io/x/conn/v3/pin/pinreg"
-	"periph.io/x/host/v3/allwinner"
-	"periph.io/x/host/v3/chip"
 )
 
 // SmokeTest is imported by periph-smoketest.

--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"time"
 
-	"periph.io/x/host/v3/fs"
+	"adev73/x/host/v3/fs"
 )
 
 // MaxSpeed returns the processor maximum speed in Hz.

--- a/cpu/cpu_test.go
+++ b/cpu/cpu_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"periph.io/x/host/v3/fs"
+	"adev73/x/host/v3/fs"
 )
 
 func TestMaxSpeed_fail(t *testing.T) {

--- a/distro/distro_test.go
+++ b/distro/distro_test.go
@@ -9,7 +9,7 @@ import (
 	"reflect"
 	"testing"
 
-	"periph.io/x/host/v3/fs"
+	"adev73/x/host/v3/fs"
 )
 
 func TestSplitSemiColon(t *testing.T) {

--- a/example_test.go
+++ b/example_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"log"
 
-	"periph.io/x/host/v3"
+	"adev73/x/host/v3"
 )
 
 func ExampleInit() {

--- a/ftdi/example_test.go
+++ b/ftdi/example_test.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"log"
 
-	"periph.io/x/host/v3"
-	"periph.io/x/host/v3/ftdi"
+	"adev73/x/host/v3"
+	"adev73/x/host/v3/ftdi"
 )
 
 func Example() {

--- a/ftdi/ftdismoketest/ftdismoketest.go
+++ b/ftdi/ftdismoketest/ftdismoketest.go
@@ -12,8 +12,9 @@ import (
 	"fmt"
 	"time"
 
+	"adev73/x/host/v3/ftdi"
+
 	"periph.io/x/conn/v3/gpio"
-	"periph.io/x/host/v3/ftdi"
 )
 
 // SmokeTest is imported by periph-smoketest.

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
-module periph.io/x/host/v3
+module adev73/x/host/v3
 
 go 1.13
 

--- a/host.go
+++ b/host.go
@@ -8,7 +8,7 @@ import (
 	"periph.io/x/conn/v3/driver/driverreg"
 	// TODO(maruel): For now do not include ftdi by default. It's not stable
 	// enough to warrant being included.
-	// _ "periph.io/x/host/v3/ftdi"
+	// _ "adev73/x/host/v3/ftdi"
 )
 
 // Init calls driverreg.Init() and returns it as-is.

--- a/host_arm.go
+++ b/host_arm.go
@@ -6,16 +6,16 @@ package host
 
 import (
 	// Make sure CPU and board drivers are registered.
-	_ "periph.io/x/host/v3/allwinner"
-	_ "periph.io/x/host/v3/am335x"
-	_ "periph.io/x/host/v3/bcm283x"
-	_ "periph.io/x/host/v3/beagle/bone"
-	_ "periph.io/x/host/v3/beagle/green"
-	_ "periph.io/x/host/v3/chip"
-	_ "periph.io/x/host/v3/odroidc1"
+	_ "adev73/x/host/v3/allwinner"
+	_ "adev73/x/host/v3/am335x"
+	_ "adev73/x/host/v3/bcm283x"
+	_ "adev73/x/host/v3/beagle/bone"
+	_ "adev73/x/host/v3/beagle/green"
+	_ "adev73/x/host/v3/chip"
+	_ "adev73/x/host/v3/odroidc1"
 
 	// While this board is ARM64, it may run ARM 32 bits binaries so load it on
 	// 32 bits builds too.
-	_ "periph.io/x/host/v3/pine64"
-	_ "periph.io/x/host/v3/rpi"
+	_ "adev73/x/host/v3/pine64"
+	_ "adev73/x/host/v3/rpi"
 )

--- a/host_arm64.go
+++ b/host_arm64.go
@@ -6,8 +6,8 @@ package host
 
 import (
 	// Make sure CPU and board drivers are registered.
-	_ "periph.io/x/host/v3/allwinner"
-	_ "periph.io/x/host/v3/bcm283x"
-	_ "periph.io/x/host/v3/pine64"
-	_ "periph.io/x/host/v3/rpi"
+	_ "adev73/x/host/v3/allwinner"
+	_ "adev73/x/host/v3/bcm283x"
+	_ "adev73/x/host/v3/pine64"
+	_ "adev73/x/host/v3/rpi"
 )

--- a/host_linux.go
+++ b/host_linux.go
@@ -6,5 +6,5 @@ package host
 
 import (
 	// Make sure sysfs drivers are registered.
-	_ "periph.io/x/host/v3/sysfs"
+	_ "adev73/x/host/v3/sysfs"
 )

--- a/mt7688/driver.go
+++ b/mt7688/driver.go
@@ -8,7 +8,7 @@ package mt7688
 import (
 	"errors"
 
-	"periph.io/x/host/v3/sysfs"
+	"adev73/x/host/v3/sysfs"
 )
 
 // driverGPIO implements periph.Driver.

--- a/mt7688/mt7688.go
+++ b/mt7688/mt7688.go
@@ -7,8 +7,9 @@ package mt7688
 import (
 	"strings"
 
+	"adev73/x/host/v3/distro"
+
 	"periph.io/x/conn/v3/driver/driverreg"
-	"periph.io/x/host/v3/distro"
 )
 
 // Present returns true if a mt7688 processor is detected.

--- a/mt7688/pin.go
+++ b/mt7688/pin.go
@@ -8,10 +8,11 @@ import (
 	"errors"
 	"time"
 
+	"adev73/x/host/v3/sysfs"
+
 	"periph.io/x/conn/v3/gpio"
 	"periph.io/x/conn/v3/physic"
 	"periph.io/x/conn/v3/pin"
-	"periph.io/x/host/v3/sysfs"
 )
 
 // function specifies the active functionality of a pin. The alternative

--- a/odroidc1/odroidc1.go
+++ b/odroidc1/odroidc1.go
@@ -9,13 +9,14 @@ import (
 	"strconv"
 	"strings"
 
+	"adev73/x/host/v3/distro"
+	"adev73/x/host/v3/sysfs"
+
 	"periph.io/x/conn/v3/driver/driverreg"
 	"periph.io/x/conn/v3/gpio"
 	"periph.io/x/conn/v3/gpio/gpioreg"
 	"periph.io/x/conn/v3/pin"
 	"periph.io/x/conn/v3/pin/pinreg"
-	"periph.io/x/host/v3/distro"
-	"periph.io/x/host/v3/sysfs"
 )
 
 // The J2 header is rPi compatible, except for the two analog pins and the 1.8V

--- a/odroidc1/odroidc1smoketest/odroidc1smoketest.go
+++ b/odroidc1/odroidc1smoketest/odroidc1smoketest.go
@@ -13,10 +13,11 @@ import (
 	"sort"
 	"strconv"
 
+	"adev73/x/host/v3/odroidc1"
+
 	"periph.io/x/conn/v3/gpio"
 	"periph.io/x/conn/v3/gpio/gpioreg"
 	"periph.io/x/conn/v3/pin/pinreg"
-	"periph.io/x/host/v3/odroidc1"
 )
 
 // SmokeTest is imported by periph-smoketest.

--- a/pine64/pine64.go
+++ b/pine64/pine64.go
@@ -8,11 +8,12 @@ import (
 	"errors"
 	"strings"
 
+	"adev73/x/host/v3/allwinner"
+	"adev73/x/host/v3/distro"
+
 	"periph.io/x/conn/v3/driver/driverreg"
 	"periph.io/x/conn/v3/pin"
 	"periph.io/x/conn/v3/pin/pinreg"
-	"periph.io/x/host/v3/allwinner"
-	"periph.io/x/host/v3/distro"
 )
 
 // Present returns true if running on a Pine64 board.

--- a/pmem/example_test.go
+++ b/pmem/example_test.go
@@ -7,7 +7,7 @@ package pmem_test
 import (
 	"log"
 
-	"periph.io/x/host/v3/pmem"
+	"adev73/x/host/v3/pmem"
 )
 
 func ExampleMapAsPOD() {

--- a/pmem/view.go
+++ b/pmem/view.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"unsafe"
 
-	"periph.io/x/host/v3/fs"
+	"adev73/x/host/v3/fs"
 )
 
 // Slice can be transparently viewed as []byte, []uint32 or a struct.

--- a/pmem/view_test.go
+++ b/pmem/view_test.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"testing"
 
-	"periph.io/x/host/v3/fs"
+	"adev73/x/host/v3/fs"
 )
 
 func TestSlice(t *testing.T) {

--- a/rpi/rpi.go
+++ b/rpi/rpi.go
@@ -11,12 +11,13 @@ import (
 	"fmt"
 	"os"
 
+	"adev73/x/host/v3/bcm283x"
+	"adev73/x/host/v3/distro"
+
 	"periph.io/x/conn/v3/driver/driverreg"
 	"periph.io/x/conn/v3/gpio"
 	"periph.io/x/conn/v3/pin"
 	"periph.io/x/conn/v3/pin/pinreg"
-	"periph.io/x/host/v3/bcm283x"
-	"periph.io/x/host/v3/distro"
 )
 
 // Present returns true if running on a Raspberry Pi board.

--- a/serial/serial.go
+++ b/serial/serial.go
@@ -49,6 +49,11 @@ func Enumerate() ([]int, error) {
 	return out, nil
 }
 
+func New(portNumber int) (*Port, error) {
+	// Expose newPortDevFs to allow a program to actually get access to a serial port
+	return newPortDevFs(portNumber)
+}
+
 func newPortDevFs(portNumber int) (*Port, error) {
 	// Use the devfs path for now.
 	name := fmt.Sprintf("ttyS%d", portNumber)
@@ -75,6 +80,23 @@ func (p *Port) Close() error {
 // String implements uart.Port.
 func (p *Port) String() string {
 	return p.conn.String()
+}
+
+// Implement the "missing" methods of a serial port that we need to use it properly
+
+// Duplex implements conn.Conn.
+func (p *Port) Duplex() conn.Duplex {
+	return conn.Full
+}
+
+// Read implements io.Reader.
+func (p *Port) Read(b []byte) (int, error) {
+	return p.conn.f.Read(b)
+}
+
+// Write implements io.Writer.
+func (p *Port) Write(b []byte) (int, error) {
+	return p.conn.f.Write(b)
 }
 
 // Connect implements uart.Port.

--- a/sysfs/example_test.go
+++ b/sysfs/example_test.go
@@ -8,9 +8,10 @@ import (
 	"fmt"
 	"log"
 
+	"adev73/x/host/v3"
+	"adev73/x/host/v3/sysfs"
+
 	"periph.io/x/conn/v3/gpio"
-	"periph.io/x/host/v3"
-	"periph.io/x/host/v3/sysfs"
 )
 
 func ExampleLEDByName() {

--- a/sysfs/gpio.go
+++ b/sysfs/gpio.go
@@ -14,13 +14,14 @@ import (
 	"sync"
 	"time"
 
+	"adev73/x/host/v3/fs"
+
 	"periph.io/x/conn/v3"
 	"periph.io/x/conn/v3/driver/driverreg"
 	"periph.io/x/conn/v3/gpio"
 	"periph.io/x/conn/v3/gpio/gpioreg"
 	"periph.io/x/conn/v3/physic"
 	"periph.io/x/conn/v3/pin"
-	"periph.io/x/host/v3/fs"
 )
 
 // Pins is all the pins exported by GPIO sysfs.

--- a/sysfs/led.go
+++ b/sysfs/led.go
@@ -14,12 +14,13 @@ import (
 	"sync"
 	"time"
 
+	"adev73/x/host/v3/fs"
+
 	"periph.io/x/conn/v3"
 	"periph.io/x/conn/v3/driver/driverreg"
 	"periph.io/x/conn/v3/gpio"
 	"periph.io/x/conn/v3/physic"
 	"periph.io/x/conn/v3/pin"
-	"periph.io/x/host/v3/fs"
 )
 
 // LEDs is all the leds discovered on this host via sysfs.

--- a/sysfs/spi.go
+++ b/sysfs/spi.go
@@ -17,6 +17,8 @@ import (
 	"sync"
 	"unsafe"
 
+	"adev73/x/host/v3/fs"
+
 	"periph.io/x/conn/v3"
 	"periph.io/x/conn/v3/driver/driverreg"
 	"periph.io/x/conn/v3/gpio"
@@ -24,7 +26,6 @@ import (
 	"periph.io/x/conn/v3/physic"
 	"periph.io/x/conn/v3/spi"
 	"periph.io/x/conn/v3/spi/spireg"
-	"periph.io/x/host/v3/fs"
 )
 
 // NewSPI opens a SPI port via its devfs interface as described at

--- a/sysfs/sysfs.go
+++ b/sysfs/sysfs.go
@@ -7,7 +7,7 @@ package sysfs
 import (
 	"io"
 
-	"periph.io/x/host/v3/fs"
+	"adev73/x/host/v3/fs"
 )
 
 var ioctlOpen = ioctlOpenDefault

--- a/sysfs/sysfs_test.go
+++ b/sysfs/sysfs_test.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"io"
 
-	"periph.io/x/host/v3/fs"
+	"adev73/x/host/v3/fs"
 )
 
 func init() {

--- a/sysfs/sysfssmoketest/benchmark.go
+++ b/sysfs/sysfssmoketest/benchmark.go
@@ -10,8 +10,9 @@ import (
 	"fmt"
 	"sort"
 
+	"adev73/x/host/v3/sysfs"
+
 	"periph.io/x/conn/v3/gpio"
-	"periph.io/x/host/v3/sysfs"
 )
 
 // Benchmark is imported by periph-smoketest.

--- a/videocore/example_test.go
+++ b/videocore/example_test.go
@@ -7,7 +7,7 @@ package videocore_test
 import (
 	"log"
 
-	"periph.io/x/host/v3/videocore"
+	"adev73/x/host/v3/videocore"
 )
 
 func ExampleAlloc() {

--- a/videocore/videocore.go
+++ b/videocore/videocore.go
@@ -20,8 +20,8 @@ import (
 	"sync"
 	"unsafe"
 
-	"periph.io/x/host/v3/fs"
-	"periph.io/x/host/v3/pmem"
+	"adev73/x/host/v3/fs"
+	"adev73/x/host/v3/pmem"
 )
 
 // Mem represents contiguous physically locked memory that was allocated by

--- a/videocore/videocore_test.go
+++ b/videocore/videocore_test.go
@@ -8,8 +8,8 @@ import (
 	"errors"
 	"testing"
 
-	"periph.io/x/host/v3/fs"
-	"periph.io/x/host/v3/pmem"
+	"adev73/x/host/v3/fs"
+	"adev73/x/host/v3/pmem"
 )
 
 func TestClose(t *testing.T) {


### PR DESCRIPTION
This PR fixes a problem with the Serial port implementation, whereby:
1. It was not possible to correctly instantiate a serial port object
2. Read/Write methods were unreachable as implemented on private "conn" property of Port, and not exposed via conn.Conn interface

Please note: This is a "bare minimum" set of changes, to allow me to use periph.io's serial capabilities. It currently ONLY works on Linux machines, and it only works if you have ttySerialX type ports symlinked in your /dev folder.

Yet TODO: Implement it for Windows. Improve to address Manuel's TODOs. Allow other /dev/ttyX types to be treated as serial ports. Better error handling. Loads...