### PR TITLE
fs,sysfs: use EPOLL_EXEC to clean up epoll file descriptors on execve(2)

### DIFF
--- a/fs/fs_linux.go
+++ b/fs/fs_linux.go
@@ -95,13 +95,13 @@ type event struct {
 // syscall.EpollCreate: http://man7.org/linux/man-pages/man2/epoll_create.2.html
 // syscall.EpollCtl: http://man7.org/linux/man-pages/man2/epoll_ctl.2.html
 func (e *event) makeEvent(fd uintptr) error {
-	epollFd, err := syscall.EpollCreate(1)
+	epollFd, err := syscall.EpollCreate1(syscall.EPOLL_CLOEXEC)
 	switch {
 	case err == nil:
 		break
 	case err.Error() == "function not implemented":
-		// Some arch (arm64) do not implement EpollCreate().
-		if epollFd, err = syscall.EpollCreate1(0); err != nil {
+		// Fall back to epoll_create.
+		if epollFd, err = syscall.EpollCreate(1); err != nil {
 			return err
 		}
 	default:

--- a/sysfs/fs_linux.go
+++ b/sysfs/fs_linux.go
@@ -132,13 +132,13 @@ func (e *eventsListener) init() error {
 
 func (e *eventsListener) initLocked() error {
 	var err error
-	e.epollFd, err = syscall.EpollCreate(1)
+	e.epollFd, err = syscall.EpollCreate1(syscall.EPOLL_CLOEXEC)
 	switch {
 	case err == nil:
 		break
 	case err.Error() == "function not implemented":
-		// Some arch (arm64) do not implement EpollCreate().
-		if e.epollFd, err = syscall.EpollCreate1(0); err != nil {
+		// Fall back to epoll_create.
+		if e.epollFd, err = syscall.EpollCreate(1); err != nil {
 			return err
 		}
 	default:


### PR DESCRIPTION
EPOLL_EXEC is O_CLOEXEC for epoll_create1, which is a good default for any file descriptor not explicitly designed to survive an exec.