### PR TITLE
netlink: Issue #60, fix onewire not present, and hanging when it is.

### DIFF
--- a/host_linux.go
+++ b/host_linux.go
@@ -7,5 +7,6 @@ package host
 import (
 	// Make sure required drivers are registered.
 	_ "periph.io/x/host/v3/gpioioctl"
+	_ "periph.io/x/host/v3/netlink"
 	_ "periph.io/x/host/v3/sysfs"
 )

--- a/netlink/netlink_linux.go
+++ b/netlink/netlink_linux.go
@@ -6,6 +6,7 @@ package netlink
 
 import (
 	"fmt"
+	"path/filepath"
 	"syscall"
 )
 
@@ -51,4 +52,18 @@ func (s *connSocket) close() error {
 	fd := s.fd
 	s.fd = 0
 	return syscall.Close(fd)
+}
+
+// isOneWireAvailable checks to see if the Linux onewire bus drivers are loaded.
+// It does this by looking for entries in the /sys/bus pseudo-filesystem.
+//
+// On a Raspberry Pi SBC, the onewire bus is enabled by creating entries in the
+// kernel config.txt file which is located in /boot, or /boot/firmware depending
+// on OS/kernel levels.
+func isOneWireAvailable() bool {
+	items, err := filepath.Glob("/sys/bus/w1/devices/*")
+	if err != nil || len(items) == 0 {
+		return false
+	}
+	return true
 }

--- a/netlink/netlink_other.go
+++ b/netlink/netlink_other.go
@@ -28,3 +28,7 @@ func (*connSocket) recv(_ []byte) (int, error) {
 func (*connSocket) close() error {
 	return errors.New("not implemented")
 }
+
+func isOneWireAvailable() bool {
+	return false
+}

--- a/netlink/onewire.go
+++ b/netlink/onewire.go
@@ -463,6 +463,9 @@ func (d *driver1W) After() []string {
 }
 
 func (d *driver1W) Init() (bool, error) {
+	if !isOneWireAvailable() {
+		return false, errors.New("no onewire buses found")
+	}
 	s, err := newW1Socket()
 	if err != nil {
 		return false, fmt.Errorf("netlink-onewire: failed to open socket: %v", err)


### PR DESCRIPTION
Fixes Issue #60, periph-cmd/onewire-list not working because the netlink package wasn't initialized.

There is a problem with loading netlink when the onewire bus drivers aren't loaded. If you run an executable with the netlink package loaded, and the onewire driver isn't loaded, the application hangs indefinitely. This was causing pipeline failures. It appears that netlink.Init() is sending a request on the netlink interface for onewire masters, but nothing is responding so it hangs.

My initial thought to resolve the hang was to put a network timeout on the request for onewire bus master. However, I think the approach of looking at the /sys/bus pseudo-filesystem is cleaner.

I'll follow up this PR with one to periph-cmd to do small fixes to onewire-list and add and ds18b20 program.